### PR TITLE
Make installable as shill plugin

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -1,0 +1,6 @@
+#lang info
+
+(define shill-plugin-name 'db)
+(define shill-plugin-require '("db_api.rkt"))
+(define shill-plugin-ambient '(make-dbview))
+(define shill-plugin-interfaces '(dbview))


### PR DESCRIPTION
I added an `info.rkt` file so that when installed, the API will be available from shill as a plugin.
To install, invoke `raco pkg install` from inside the repository's directory.
You can then import the plugin in shill using `(import (plugin db))`.
I also did a little bit of code cleanup in the API definition.