### PR TITLE
update to use new API

### DIFF
--- a/examples/blog/blog.shill
+++ b/examples/blog/blog.shill
@@ -6,8 +6,8 @@
 ;
 ; Usage example from shill prompt: 
 ; > (import (plugin db))
-; > (define/contract uv blogview/c (make-dbview "blog.db" "users"))
-; > (define/contract pv blogview/c (make-dbview "blog.db" "posts"))
+; > (define/contract uv blogview/c (open-dbview "blog.db" "users"))
+; > (define/contract pv blogview/c (open-dbview "blog.db" "posts"))
 ; 
 ; Display all of Bob's posts
 ; > (main uv pv "Bob" "list")
@@ -24,7 +24,7 @@
 ; (export (contract-out [main (-> blogview/c blogview/c string? string? any/c)]))
 (export main)
 
-(define blogview/c (dbview/c (fetch/p) (where/p)))
+(define blogview/c (dbview/c fetch/p where/p))
 
 ; Given a view which should correspond to a single user's view into the posts
 ; database, list out all of the posts that user can view in a readable form.

--- a/examples/employees/employees.shill
+++ b/examples/employees/employees.shill
@@ -6,11 +6,11 @@
 (export give_raise)
 (export eview/c)
 
-(define eview/c (dbview/c (fetch/p) (select/p) (join/p) (where/p) (update/p)))
+(define eview/c (dbview/c fetch/p select/p join/p where/p update/p))
 
 ; Throughout, we assume the following definitions:
-; > (define/contract s eview/c (make-dbview "employees.db" "salaries"))
-; > (define/contract e eview/c (make-dbview "employees.db" "employees"))
+; > (define/contract s eview/c (open-dbview "employees.db" "salaries"))
+; > (define/contract e eview/c (open-dbview "employees.db" "employees"))
 
 ; A simple example of a company employee database. 
 ; In this example, the company data is stored in two tables:

--- a/info.rkt
+++ b/info.rkt
@@ -2,5 +2,6 @@
 
 (define shill-plugin-name 'db)
 (define shill-plugin-require 'db_api/db_api)
-(define shill-plugin-ambient '(make-dbview print-fetch-res))
-(define shill-plugin-interfaces '(dbview))
+(define shill-plugin-ambient '(open-dbview print-fetch-res))
+(define shill-plugin-capabilities '(dbview))
+(define shill-plugin-operations '(where select join fetch delete update insert))


### PR DESCRIPTION
I've rewritten the shill plugin API to center around operations instead of capabilities.
This provides better support for operations that involve more than one capability.

The major changes are replacing `capability` and `interface` with a simpler `capability` syntax and new constructs `define-operation` and `define-instance`. The syntax for specifying contracts has changed as well.

Instead of `(somecap/c (somepriv/p))` you write `(somecap/c somepriv/p)`. And instead of `(somecap/c (somepriv/p #:deriving whatever))`, you now write `(some/cap/c (somepriv/p x y -> (result : (cap/c whatever))`, where the syntax for `somepriv/p` is a signature like proc/p from this library I wrote: https://docs.racket-lang.org/signature/index.html?q=signature.